### PR TITLE
refactor(auth): remove email field from ForgotUpdatePassword interface

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@think-storm/contracts",
-  "version": "1.0.8",
+  "version": "1.0.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@think-storm/contracts",
-      "version": "1.0.8",
+      "version": "1.0.23",
       "license": "ISC",
       "dependencies": {
         "@types/node": "^22.14.1",

--- a/src/interface/auth.interface.ts
+++ b/src/interface/auth.interface.ts
@@ -10,7 +10,6 @@ export interface RegisterUser {
 }
 
 export interface ForgotUpdatePassword {
-  email: string;
   password: string;
   passwordResetToken: string;
 }


### PR DESCRIPTION
## Related Issue

- Frontend Issue #40: Password Recovery Flow

## Description

- The `ForgotUpdatePassword` interface has removed the `email` field

## Required Follow-up / Note

- This PR should be merged **first**.  
- Once merged, proceed with the related **backend** and **frontend** PRs to implement the corresponding updates.  
- Both backend and frontend PRs must include the interface changes listed below to ensure the feature works correctly.

```ts
export interface ForgotUpdatePassword {
  password: string;
  passwordResetToken: string;
}
```

## Reviewers

- @kimdahee0815 @Harian-Elyoth
