### PR TITLE
Add UpdateJoinRequest and LikeProject interfaces

### DIFF
--- a/src/common/types/notification.types.ts
+++ b/src/common/types/notification.types.ts
@@ -1,6 +1,7 @@
 export enum NotificationType {
   JoinRequest = "JoinRequest",
   AcceptJoinRequest = "AcceptJoinRequest",
+  RejectJoinRequest = "RejectJoinRequest",
   InviteToProject = "InviteToProject",
   Welcome = "Welcome",
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,9 @@ export {
   JoinRequestResponse,
   SearchProjectResponse,
   CreateJoinRequest,
+  UpdateJoinRequest,
   Saveproject,
+  LikeProject,
 } from "./interface/project.interface";
 
 // Newsletter

--- a/src/interface/project.interface.ts
+++ b/src/interface/project.interface.ts
@@ -1,4 +1,4 @@
-import { Goal, ProjectStatus } from "../common/types/project.types";
+import { Goal, ProjectStatus, JoinRequestStatus } from "../common/types/project.types";
 import { LanguageName } from "../common/types/language.types";
 import { User } from "../common/types/user.types";
 
@@ -90,6 +90,15 @@ export interface CreateJoinRequest {
     message?: string;
 }
 
+export interface UpdateJoinRequest {
+    status: JoinRequestStatus;
+}
+
 export interface Saveproject {
     saved_by_users?: number[];
+}
+
+export interface LikeProject {
+    userId: number;
+    projectId: number;
 }


### PR DESCRIPTION
## Summary
This PR adds two new interfaces to support additional project management features: updating join requests and liking projects.

## Key Changes
- Added `JoinRequestStatus` import to the project interface file
- Created `UpdateJoinRequest` interface to handle join request status updates with a `status` field of type `JoinRequestStatus`
- Created `LikeProject` interface to represent project likes with `userId` and `projectId` fields
- Exported both new interfaces from the main index file for public API consumption

## Implementation Details
- The `UpdateJoinRequest` interface provides a simple contract for updating the status of a join request
- The `LikeProject` interface captures the relationship between a user and a project for like functionality
- Both interfaces are now available as part of the public API exports

https://claude.ai/code/session_016gFbJepjzq7qCMtE4xdKEq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added notifications when project join requests are rejected
  * Users can now like projects to show interest
  * Enhanced project join request management with status tracking capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->